### PR TITLE
#1-Allow---testlevel-and--runtests-as-optional-parameters

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,14 @@ inputs:
     description: 'When pushing to org, should we only validate or actually deploy'
     required: true
     default: 'true'
+  test-level:
+    description: 'When pushing to org, sets the level of tests that should run'
+    required: false
+    default: 'NoTests'
+  specified-tests:
+    description: 'When running tests on the target org, set specified tests to run'
+    required: false
+    default: ''
   sfdx-auth-url:
     description: 'SFDX Login url for org'
     required: true
@@ -37,6 +45,8 @@ runs:
       shell: bash
       env:
         VALIDATE_ONLY: ${{ inputs.validate-only }}
+        TEST_LEVEL: ${{ inputs.test-level }}
+        SPECIFIED_TESTS: ${{ inputs.specified-tests }}
         SFDX_AUTH_URL: ${{ inputs.sfdx-auth-url }}
         REVISION_FROM: ${{ inputs.revision-from }}
         REVISION_TO: ${{ inputs.revision-to }}

--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,14 @@ inputs:
     required: true
     default: 'true'
   test-level:
-    description: 'When pushing to org, sets the level of tests that should run'
+    description: 'When pushing to org, sets the level of tests that should run: RunLocalTests - run all tests minus
+      managed packed tests in target; RunSpecifiedTests - only runs the provided test classes; NoTestRun - no tests
+      run. Production requires test classes to run if Apex is deployed. For Dev blank is default-NoTestRun, Prod default-RunLocalTests'
     required: false
-    default: 'NoTests'
+    default: ''
   specified-tests:
-    description: 'When running tests on the target org, set specified tests to run'
+    description: 'When running tests on the target org, set specified tests to run only when test-level is RunSpecifiedTest. Must be a comma delimmited
+    list of Apex Classes'
     required: false
     default: ''
   sfdx-auth-url:

--- a/sfdx-cicd.sh
+++ b/sfdx-cicd.sh
@@ -27,9 +27,11 @@ if [[ $TEST_LEVEL = 'runspecifiedtests' ]]; then
   TEST_LEVEL='--testlevel RunSpecifiedTests';
 elif [[ $TEST_LEVEL = 'runlocaltests' ]]; then
   TEST_LEVEL='--testlevel RunLocalTests';
+elif [[ $TEST_LEVEL = 'notestrun' ]]; then
+  TEST_LEVEL='--testlevel NoTestRun';
 else 
   TEST_LEVEL='';
-  echo "Setting testlevel to run RunNoTests"
+  echo "Setting testlevel to run org defaults. RunLocalTests for Prod, NoTestRun for Sandbox"
 fi
 
 SPECIFIED_TESTS=`echo $SPECIFIED_TESTS | tr -d ' '`
@@ -39,8 +41,6 @@ if [[ $TEST_LEVEL = '--testlevel RunSpecifiedTests' ]]; then
 else
   SPECIFIED_TESTS='';
 fi
-
-echo 'Test Level: ' $TEST_LEVEL 'specificTest: ' $SPECIFIED_TESTS
 
 # Auth sfdx into org with auth url
 echo $SFDX_AUTH_URL > sfdx_auth.txt

--- a/sfdx-cicd.sh
+++ b/sfdx-cicd.sh
@@ -12,7 +12,6 @@ echo 'y' | sfdx plugins:install sfpowerkit
 
 
 VALIDATE_ONLY=`echo $VALIDATE_ONLY | tr '[:upper:]' '[:lower:]'`
-echo $VALIDATE_ONLY
 if [[ $VALIDATE_ONLY = true ]]; then
   VALIDATE_FLAG='-c';
 elif [[ $VALIDATE_ONLY = false ]]; then
@@ -35,7 +34,6 @@ else
 fi
 
 SPECIFIED_TESTS=`echo $SPECIFIED_TESTS | tr -d ' '`
-echo 'Test Level: ' $TEST_LEVEL 'specificTest: ' $SPECIFIED_TESTS
 if [[ $TEST_LEVEL = '--testlevel RunSpecifiedTests' ]]; then
   SPECIFIED_TESTS="--runtests $SPECIFIED_TESTS";
 else

--- a/sfdx-cicd.sh
+++ b/sfdx-cicd.sh
@@ -10,7 +10,9 @@ export PATH=~/sfdx-cli/bin:$PATH
 # Install sfpowerkit
 echo 'y' | sfdx plugins:install sfpowerkit
 
+
 VALIDATE_ONLY=`echo $VALIDATE_ONLY | tr '[:upper:]' '[:lower:]'`
+echo $VALIDATE_ONLY
 if [[ $VALIDATE_ONLY = true ]]; then
   VALIDATE_FLAG='-c';
 elif [[ $VALIDATE_ONLY = false ]]; then
@@ -20,13 +22,35 @@ else
   exit 2
 fi
 
+TEST_LEVEL=`echo $TEST_LEVEL | tr '[:upper:]' '[:lower:]'`
+if [[ $TEST_LEVEL = 'runspecifiedtests' ]]; then
+  TEST_LEVEL='--testlevel RunSpecifiedTests';
+elif [[ $TEST_LEVEL = 'runlocaltests' ]]; then
+  TEST_LEVEL='--testlevel RunLocalTests';
+else 
+  TEST_LEVEL='';
+  echo "Setting testlevel to run RunNoTests"
+fi
+
+SPECIFIED_TESTS=`echo $SPECIFIED_TESTS | tr -d ' '`
+echo 'Test Level: ' $TEST_LEVEL 'specificTest: ' $SPECIFIED_TESTS
+if [[ $TEST_LEVEL = '--testlevel RunSpecifiedTests' ]]; then
+  SPECIFIED_TESTS="--runtests $SPECIFIED_TESTS";
+else
+  SPECIFIED_TESTS='';
+fi
+
+echo 'Test Level: ' $TEST_LEVEL 'specificTest: ' $SPECIFIED_TESTS
+
 # Auth sfdx into org with auth url
 echo $SFDX_AUTH_URL > sfdx_auth.txt
 sfdx force:auth:sfdxurl:store -f sfdx_auth.txt -s -a SFOrg
 rm sfdx_auth.txt
 
+echo "sfdx diff command: sfdx sfpowerkit:project:diff -r $REVISION_FROM -t $REVISION_TO -d diffdeploy"
 # Prepare diff
 sfdx sfpowerkit:project:diff -r $REVISION_FROM -t $REVISION_TO -d diffdeploy
 
+echo "sfdx deploy command: sfdx force:source:deploy -p diffdeploy/force-app -u SFOrg --json --loglevel fatal $VALIDATE_FLAG $TEST_LEVEL $SPECIFIED_TESTS --apiversion=$API_VERSION"
 # Deploy diff
-sfdx force:source:deploy -p diffdeploy/force-app -u SFOrg --json --loglevel fatal $VALIDATE_FLAG --apiversion=$API_VERSION
+sfdx force:source:deploy -p diffdeploy/force-app -u SFOrg --json --loglevel fatal $VALIDATE_FLAG $TEST_LEVEL $SPECIFIED_TESTS --apiversion=$API_VERSION


### PR DESCRIPTION
Adding the ability to set the test level and specify specific tests. This increases flexibility and also allows us to create a quick deploy link in production.